### PR TITLE
Add x-client-trace-id Header to All Requests

### DIFF
--- a/java/src/main/java/utility/APISessionCredentials.java
+++ b/java/src/main/java/utility/APISessionCredentials.java
@@ -22,8 +22,6 @@ public class APISessionCredentials extends CallCredentials {
     public static final Metadata.Key<String> SESSION_TOKEN_KEY = keyOf("accessToken");
     // Tenant Id of the customer org
     public static final Metadata.Key<String> TENANT_ID_KEY = keyOf("tenantId");
-    // Client trace Id to trace the requests
-    public static final Metadata.Key<String> CLIENT_TRACE_ID_KEY = keyOf("x-client-trace-id");
 
     private String instanceURL;
     private String tenantId;
@@ -39,14 +37,11 @@ public class APISessionCredentials extends CallCredentials {
 
     @Override
     public void applyRequestMetadata(RequestInfo requestInfo, Executor executor, MetadataApplier metadataApplier) {
-        String clientTraceId = UUID.randomUUID().toString();
-        log.info("Client Trace Id for current request: " + clientTraceId);
         log.debug("API session credentials applied to " + requestInfo.getMethodDescriptor());
         Metadata headers = new Metadata();
         headers.put(INSTANCE_URL_KEY, instanceURL);
         headers.put(TENANT_ID_KEY, tenantId);
         headers.put(SESSION_TOKEN_KEY, token);
-        headers.put(CLIENT_TRACE_ID_KEY, clientTraceId);
         metadataApplier.apply(headers);
     }
 

--- a/java/src/main/java/utility/CommonContext.java
+++ b/java/src/main/java/utility/CommonContext.java
@@ -65,8 +65,10 @@ public class CommonContext implements AutoCloseable {
         callCredentials = setupCallCredentials(options);
         sessionToken = ((APISessionCredentials) callCredentials).getToken();
 
-        asyncStub = PubSubGrpc.newStub(channel).withCallCredentials(callCredentials);
-        blockingStub = PubSubGrpc.newBlockingStub(channel).withCallCredentials(callCredentials);
+        Channel interceptedChannel = ClientInterceptors.intercept(channel, new XClientTraceIdClientInterceptor());
+
+        asyncStub = PubSubGrpc.newStub(interceptedChannel).withCallCredentials(callCredentials);
+        blockingStub = PubSubGrpc.newBlockingStub(interceptedChannel).withCallCredentials(callCredentials);
     }
 
     /**

--- a/java/src/main/java/utility/XClientTraceIdClientInterceptor.java
+++ b/java/src/main/java/utility/XClientTraceIdClientInterceptor.java
@@ -1,0 +1,35 @@
+package utility;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.grpc.*;
+
+public class XClientTraceIdClientInterceptor implements ClientInterceptor {
+    private static final Logger logger = LoggerFactory.getLogger(XClientTraceIdClientInterceptor.class.getClass());
+    private static final Metadata.Key<String> X_CLIENT_TRACE_ID = Metadata.Key.of("x-client-trace-id", Metadata.ASCII_STRING_MARSHALLER);
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+                                                               CallOptions callOptions, Channel next) {
+        return new ForwardingClientCall.SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                String xClientTraceId = UUID.randomUUID().toString();
+                headers.put(X_CLIENT_TRACE_ID, xClientTraceId);
+                logger.info("sending request for xClientTraceId {}", xClientTraceId);
+
+                super.start(new ForwardingClientCallListener.SimpleForwardingClientCallListener<>(responseListener) {
+                    @Override
+                    public void onClose(Status status, Metadata trailers) {
+                        logger.info("request completed for xClientTraceId {} with status {}", xClientTraceId, status);
+                        super.onClose(status, trailers);
+                    }
+                }, headers);
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR adds the `x-client-trace-id` header to all outbound requests. This should generate a unique value per RPC request even if the same gRPC stub is used